### PR TITLE
22.11.01(Tue) 기능 개발/개선/수정

### DIFF
--- a/src/component/docBoxList/CommonDocBoxList.tsx
+++ b/src/component/docBoxList/CommonDocBoxList.tsx
@@ -30,7 +30,7 @@ const DOCUMENT_BOX_LIST = [ //MAP
 
 const CommonDocBoxList = ( props : any) => {
     const { navigation} = props;
-    const { sortMenuState, setSortMenu} = useContext( CommonContext);
+    const { sortMenuState, setSortMenu, setTargetFullPath} = useContext( CommonContext);
     const [ isActive, setIsActive] = useState({
         Home: false,
         MyDoc: false,
@@ -40,21 +40,14 @@ const CommonDocBoxList = ( props : any) => {
         TrashDoc: false,
     });
 
-    // useLayoutEffect(() => {
-    //     setIsActive({
-    //         ...isActive,
-    //         MyDoc: true
-    //     })
-    // }, []);
+    useLayoutEffect(() => {
+        setIsActive({
+            ...isActive,
+            MyDoc: true
+        })
+    }, []);
 
-    // useEffect(() => {
-    //     // 마지막에 셋 해준걸로 다시 화면 그리고싶은데 ㅠㅠ
-    // }, [ isActive]);
-
-    //app 점프만 해주니 까 리스트 불러오는 항목 필요없
     const onClickDocBox = ( name: string, navi: any) => {
-
-        setSortMenu( '',  { sortItem:'', fileTypes:'', sortOrder:''}, null);
 
         setIsActive({
             Home: name === 'Home' ,
@@ -65,6 +58,9 @@ const CommonDocBoxList = ( props : any) => {
             TrashDoc: name === 'TrashDoc',
         });
 
+        setSortMenu( name,  { sortItem:'', fileTypes:'', sortOrder:''}, null);
+        setTargetFullPath( [''], ['내 문서함'], null);
+
         navigation.navigate( navi);
     };
 
@@ -73,7 +69,7 @@ const CommonDocBoxList = ( props : any) => {
             {/* {console.log(isActive)} */}
             <View style={ dialogStyles.docBoxListContainer}>
                 <ScrollView horizontal={ true} showsHorizontalScrollIndicator={ false}>
-                { !CommonUtil.objectIsNull( DOCUMENT_BOX_LIST) &&
+                { !CommonUtil.objectIsNull( DOCUMENT_BOX_LIST) ?
                     DOCUMENT_BOX_LIST.map( list => {
                         // { console.log( list)}
                         return (
@@ -88,6 +84,8 @@ const CommonDocBoxList = ( props : any) => {
                             </TouchableOpacity>
                         )
                     })
+                    :
+                    null
                 }
                 </ScrollView>
             </View>

--- a/src/component/header/CommonHeader.tsx
+++ b/src/component/header/CommonHeader.tsx
@@ -71,7 +71,7 @@ const CommonHeader = (props: CommonHeaderInfo) => {
     return (
         <View style={ CommonHeaderStyles.mainContainer}>
             <View style={[ (headerMenuInfo && headerMenuInfo.rightDialogBtn) && CommonHeaderStyles.rightBtnStyle, CommonHeaderStyles.MenuContainer]}>
-                { (!CommonUtil.objectIsNull( headerMenuInfo) || !centerDialogState) &&
+                { (!CommonUtil.objectIsNull( headerMenuInfo) || !centerDialogState.dialogName) &&
                     <TouchableOpacity onPress={ onClickLeftBtn.bind( this, 'UserInfoICon')}>
                         <View>
                             <SvgIcon name="NoProfile" width={28} height={28}/>
@@ -158,7 +158,7 @@ const CommonHeader = (props: CommonHeaderInfo) => {
                 </View>
             }
         </View>
-    );
+    )
 }
 
 export default CommonHeader;

--- a/src/content/Home.tsx
+++ b/src/content/Home.tsx
@@ -34,7 +34,7 @@ const CONTEXT_NAME = "Home";
 
 const Home = ( props : any) => {    
     const { navigation} = props;
-    const { sortMenuState, setSortMenu, centerDialogState, targetFullPathState, setTargetFullPath} = useContext( CommonContext);
+    const { sortMenuState, setSortMenu, centerDialogState, targetFullPathState, setTargetFullPath, alertDialogState} = useContext( CommonContext);
 
     const flatListRef = useRef<any>();
     
@@ -66,6 +66,21 @@ const Home = ( props : any) => {
             // flatListRef.current?.scrollToOffset({ animated: false, offset: 0 }); //스크롤 초기화
         }
     }, [ sortMenuState]);
+
+    useEffect(() => {
+        //reqListData.dataList && reqListData.dataList.length > 0 &&
+        if( sortMenuState.contextName && sortMenuState.contextName == CONTEXT_NAME &&  targetFullPathState.fullPathUIDs.length > 0) {
+            //pageNum:1 은 어디선가 스크롤 값이 자동으로 바뀌면서 onEndReached() 함수가 실행되고 있어서 pageNum값이 늘어나서 생겨난 문제, 일시적으로 추가함
+            setDataList( {...reqListData, folderSeq: targetFullPathState.fullPathUIDs[targetFullPathState.fullPathUIDs.length - 1], pageNum:1, dataList: []});
+        }
+    }, [ targetFullPathState]);
+
+    useEffect(() => {
+        //다이얼로그 닫혀도 데이터리스트 불러오지 않아도 되는 메뉴가 있을 경우 예외처리 필요
+        if( sortMenuState.contextName && sortMenuState.contextName == CONTEXT_NAME) {
+            setDataList( {...reqListData, folderSeq: targetFullPathState.fullPathUIDs[targetFullPathState.fullPathUIDs.length - 1], pageNum:1, dataList: []});
+        }
+    }, [ centerDialogState, alertDialogState]);
 
     const onEndReached = async() => {
         if( isLoading) {
@@ -103,7 +118,7 @@ const Home = ( props : any) => {
                 <View style={ MyDocStyles.docListContainer}>
                     { reqListData.dataList.length > 0 ? 
                             <>
-                                { centerDialogState && targetFullPathState.fullPathUIDs.length > 1 &&
+                                { targetFullPathState.fullPathUIDs.length > 1 &&
                                     <CommonMovePath targetFullPathState={ targetFullPathState} setTargetFullPath={ setTargetFullPath} />
                                 }
                                 <CommonFlatList 
@@ -115,14 +130,17 @@ const Home = ( props : any) => {
                                 />
                             </>
                         : 
+                        <View>
+                            <CommonMovePath targetFullPathState={ targetFullPathState} setTargetFullPath={ setTargetFullPath} />
                             <Text>등록된 문서가 없습니다.</Text>
+                        </View>
                     }
                 </View>
 
                 <FloatingMenu />
             </View>
         </SafeAreaView>
-    ), [ reqListData.dataList]);
+    ), [ reqListData.dataList])
 }
 
 export default Home;

--- a/src/content/MyDoc_F.tsx
+++ b/src/content/MyDoc_F.tsx
@@ -69,18 +69,17 @@ const MyDoc = ( props : any) => {
         }
     }, []);
 
-    useEffect(() => { // unmount, context Api 초기화
-        // if( CommonUtil.strIsNull( sortMenuState.contextName) || sortMenuState.contextName !== CONTEXT_NAME) {
-        //     setSortMenu( CONTEXT_NAME, { sortItem:'1', fileTypes:'', sortOrder:'d'}, myDocMenuInfo[ 'sortMenu']);
-        // }
-        if(sortMenuState.contextName && sortMenuState.contextName == CONTEXT_NAME && sortMenuState.selectedValue != null && (sortItem !== sortMenuState.selectedValue.sortItem || fileTypes !== sortMenuState.selectedValue.fileTypes ||  sortOrder !== sortMenuState.selectedValue.sortOrder)) {
+    useEffect(() => {
+        if(sortMenuState.contextName && sortMenuState.contextName == CONTEXT_NAME && 
+            sortMenuState.selectedValue != null && (sortItem !== sortMenuState.selectedValue.sortItem || fileTypes !== sortMenuState.selectedValue.fileTypes ||  sortOrder !== sortMenuState.selectedValue.sortOrder)) {
             setDataList({ ...reqListData, pageNum: 1, sortItem:sortMenuState.selectedValue.sortItem, fileTypes:sortMenuState.selectedValue.fileTypes, sortOrder: sortMenuState.selectedValue.sortOrder, dataList: []});
-            flatListRef.current.scrollToOffset({ animated: false, offset: 0 }); //스크롤 초기화
+            // flatListRef.current?.scrollToOffset({ animated: false, offset: 0 }); //스크롤 초기화
         }
     }, [ sortMenuState]);
 
     useEffect(() => {
-        if( sortMenuState.contextName && sortMenuState.contextName == CONTEXT_NAME && reqListData.dataList && reqListData.dataList.length > 0 && targetFullPathState.fullPathUIDs.length > 0) {
+        // && reqListData.dataList && reqListData.dataList.length > 0
+        if( sortMenuState.contextName && sortMenuState.contextName == CONTEXT_NAME && targetFullPathState.fullPathUIDs.length > 0) {
             //pageNum:1 은 어디선가 스크롤 값이 자동으로 바뀌면서 onEndReached() 함수가 실행되고 있어서 pageNum값이 늘어나서 생겨난 문제, 일시적으로 추가함
             setDataList( {...reqListData, folderSeq: targetFullPathState.fullPathUIDs[targetFullPathState.fullPathUIDs.length - 1], pageNum:1, dataList: []});
         }
@@ -129,10 +128,9 @@ const MyDoc = ( props : any) => {
                 <TextInput style={ MyDocStyles.textInputStyle} placeholder="Search" />
                 
                 <View style={ MyDocStyles.docListContainer}>
-                    {
-                        reqListData.dataList.length > 0 ? 
+                    { reqListData.dataList.length > 0 ? 
                         <>
-                            { centerDialogState && targetFullPathState.fullPathUIDs.length > 1 &&
+                            { targetFullPathState.fullPathUIDs.length > 1 &&
                                 <CommonMovePath targetFullPathState={ targetFullPathState} setTargetFullPath={ setTargetFullPath} />
                             }
                             <CommonFlatList 
@@ -144,14 +142,17 @@ const MyDoc = ( props : any) => {
                             />
                         </>
                         :
+                        <View>
+                            <CommonMovePath targetFullPathState={ targetFullPathState} setTargetFullPath={ setTargetFullPath} />
                             <Text>등록된 문서가 없습니다.</Text>
-                        }
+                        </View>
+                    }
                 </View>
                 <FloatingMenu />
             </View>
         </SafeAreaView>
     </>
-    ), [ reqListData.dataList, listViewMode]);
+    ), [ reqListData.dataList, listViewMode])
 }
 
 export default MyDoc;

--- a/src/dialog/ModalDialog.tsx
+++ b/src/dialog/ModalDialog.tsx
@@ -31,5 +31,5 @@ export const ModalDialog = () => {
                 }
             </ModalContent>
         </Modal>
-    ), [ centerDialogState]);
+    ), [ centerDialogState])
 }

--- a/src/dialog/MoveDialog.tsx
+++ b/src/dialog/MoveDialog.tsx
@@ -9,7 +9,6 @@ import {View, Text, TouchableOpacity} from 'react-native';
 import {dialogStyles} from './style/style';
 import CommonUtil from '../utils/CommonUtil';
 import CommonHeader from '../component/header/CommonHeader';
-import FullPath from '../fullPath/index';
 import useDocList from '../hooks/useDocList';
 import FloatingMenu from '../menu/FloatingMenu';
 import CommonFlatList from '../component/CommonFlatList';
@@ -115,8 +114,7 @@ export const MoveDialog = () => {
             />
             <View style={ dialogStyles.docBoxListContainer}>
                 <>
-                    {
-                        !CommonUtil.objectIsNull( DOCUMENT_BOX_LIST) &&
+                    { !CommonUtil.objectIsNull( DOCUMENT_BOX_LIST) &&
                         DOCUMENT_BOX_LIST.map( list => {
                             return (
                                 <TouchableOpacity key={ list.title} onPress={ onClickDocBox.bind( this, list.listType)}>
@@ -132,10 +130,9 @@ export const MoveDialog = () => {
 
             {/* 문서 리스트 영역 */}
             <View style={ dialogStyles.folderListContainer}>
-                {
-                    reqListData.dataList.length > 0 ?
+                { reqListData.dataList.length > 0 ?
                         <>
-                            { centerDialogState && fullpath.fullPathUIDs.length > 1 &&
+                            { fullpath.fullPathUIDs.length > 1 &&
                                 <CommonMovePath targetFullPathState={ fullpath} setTargetFullPath={ setFullPath} />
                             }
                             <CommonFlatList
@@ -155,5 +152,5 @@ export const MoveDialog = () => {
 
             <FloatingMenu fullpath={ fullpath}  />
         </View>
-    ), [ reqListData.dataList]);
+    ), [ reqListData.dataList])
 }

--- a/src/dialog/copyDialog.tsx
+++ b/src/dialog/copyDialog.tsx
@@ -130,7 +130,7 @@ export const CopyDialog = () => {
                 {
                     reqListData.dataList.length > 0 ?
                     <>
-                        { centerDialogState && fullpath.fullPathUIDs.length > 1 &&
+                        { fullpath.fullPathUIDs.length > 1 &&
                             <CommonMovePath targetFullPathState={ fullpath} setTargetFullPath={ setFullPath} />
                         }
                         <CommonFlatList
@@ -149,5 +149,5 @@ export const CopyDialog = () => {
             </View>
             <FloatingMenu fullpath={ fullpath} />
         </View>
-    ), [ reqListData.dataList]);
+    ), [ reqListData.dataList])
 }

--- a/src/list/DefaultListItem.tsx
+++ b/src/list/DefaultListItem.tsx
@@ -88,6 +88,7 @@ const DefaultListItem = ( props:any) => {
                        </TouchableHighlight>
                    :
                    <View></View>
+                    <View></View>
                }
            </View>
        </View>


### PR DESCRIPTION
1. 문서함 내 빈 폴더 진입 후, 다른 문서함으로 이동 시, 상위 폴더 이동 버튼 사라지지 않는 오류 수정
   ( 원인: 폴더 패스 변경 인지 못하여, 리렌더링 되지 않았음 )

3. 조건식에 따라 컴포넌트 노출/미노출 시, 조건식에 빈 string('') 값 들어오면 텍스트로 인식되어, 오류 나는 문제 수정