### PR TITLE
22/11/23(Wed) 1차 개발 건

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -63,7 +63,7 @@ type AlertDialogState = {
 
 type SwipeFuncState = {
     setFavorite : boolean,
-    setDelete : boolean,
+    setReadOnly : boolean,
 }
 
 type ActionMenuState = {

--- a/src/assets/oneffice/homeIcons/ic_doc_cmt.svg
+++ b/src/assets/oneffice/homeIcons/ic_doc_cmt.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14">
+    <path fill="red" d="M0 0H14V14H0z" opacity="0.004"/>
+    <path fill="#b083f5" d="M4.552 8.883l-1.524.551a.5.5 0 0 1-.64-.64l.552-1.528a4.5 4.5 0 1 1 1.612 1.617z" transform="translate(0.172 2)"/>
+</svg>

--- a/src/context/CommonContext.tsx
+++ b/src/context/CommonContext.tsx
@@ -52,7 +52,7 @@ const CommonContext = createContext<CommonContextType>({
     },
     swipeItemState: {
         setFavorite: false,
-        setDelete : false,
+        setReadOnly : false,
     },
     
     setCurrentFolder : ( targetFolder : null) : void => {},
@@ -62,7 +62,7 @@ const CommonContext = createContext<CommonContextType>({
     setCenterDialog : ( dialogName : string, dialogItem : any) : void => {},
     setRightDialog : ( dialogName : string, dialogItem : any) : void => {},
     setAlertDialog : ( alertName : string, alertItem : any) : void => {},
-    setSwipeItem : ( setFavorite: boolean, setDelete: boolean ) : void => {},
+    setSwipeItem : ( setFavorite: boolean, setReadOnly: boolean ) : void => {},
     // setIsActionMenu : ( isActionMenu : boolean, setIsActionMenu : any, contextName : '', navigation : any) : void => {},
     setIsActionMenu : ( isActionMenu: boolean, navigation:any ) : void => {},
     setReViewDoc : ( isVisible : boolean, onClickFileView : any, onClickClose : any, onClickChangeTarget : any, setIsActionMenu : any) : void => {},
@@ -77,7 +77,7 @@ const CommonProvider = ({children} : CommonProviderProps): JSX.Element => {
     const [centerDialogState, setCenterDialogState] = useState<CenterDialogState>({ dialogName : '', dialogItem : null});
     const [rightDialogState, setRightDialogState] = useState<RightDialogState>({ dialogName : '', dialogItem : null});
     const [alertDialogState, setAlertDialogState] = useState<AlertDialogState>({ alertName : '', alertItem : null});
-    const [swipeItemState, setSwipeItemState] = useState<SwipeFuncState>({ setFavorite: false, setDelete: false });
+    const [swipeItemState, setSwipeItemState] = useState<SwipeFuncState>({ setFavorite: false, setReadOnly: false });
     // const [actionMenuState, setIsActionMenuState] = useState<ActionMenuState>({ isActionMenu : false, setIsActionMenu : null, contextName : '', navigation : null});
     const [actionMenuState, setIsActionMenuState] = useState<ActionMenuState>({ isActionMenu : false, navigation:null});
     const [reViewDocState, setReViewDocState] = useState<ReViewDocState>({ isVisible : false, onClickFileView : null, onClickClose : null, onClickChangeTarget : null, setIsActionMenu : null});
@@ -111,8 +111,8 @@ const CommonProvider = ({children} : CommonProviderProps): JSX.Element => {
         setAlertDialogState({...alertDialogState, alertName, alertItem});
     }, [alertDialogState, setAlertDialogState]);
 
-    const setSwipeItem = useCallback(( setFavorite: boolean, setDelete : boolean) => {
-        setSwipeItemState({...swipeItemState, setFavorite, setDelete});
+    const setSwipeItem = useCallback(( setFavorite: boolean, setReadOnly : boolean) => {
+        setSwipeItemState({...swipeItemState, setFavorite, setReadOnly});
     }, [ swipeItemState, setSwipeItemState ]);
 
     // const setIsActionMenu = useCallback(( isActionMenu : boolean, setIsActionMenu : any, contextName : string, navigation : any) : void => {

--- a/src/menu/ActionMenu.tsx
+++ b/src/menu/ActionMenu.tsx
@@ -41,26 +41,26 @@ import { CommonContext } from '../context/CommonContext';
    }
 */}
 const myDocMenuInfo:any = {    
-    'share':{name:'원커넥트',auth: 'Read',rightMenu: true,icon:'ActionShare',clickEvent: CommonFnUtil.onClickShare},
-    'linkCopy':{name:'링크복사',auth:'Read',rightMenu: false,icon:'ActionLinkCopy',clickEvent: CommonFnUtil.linkCopyEvent},
-    'ONECHAMBER(PDF)':{name:'PDF', auth:'Read',rightMenu: false,icon:'ActionOneSave',clickEvent: CommonFnUtil.onClickOneChamberSave},
-    'move':{name:'이동',auth: 'Read',rightMenu: false,icon:'ActionMove',clickEvent: CommonFnUtil.onClickMoveOpen},
-    'copy':{name:'사본 만들기',auth:'Update',rightMenu: false,icon:'ActionCopy',clickEvent: CommonFnUtil.onClickCopy},
-    'changeName':{name:'이름 변경', auth:'Read',rightMenu: false,icon:'ActionReName',clickEvent: CommonFnUtil.onClickRename},
-    'addOwnForm':{name:'나만의 양식 추가',auth: 'Read',rightMenu: false,icon:'ActionSetViewOnlyOFF',clickEvent: CommonFnUtil.onClickAddOwnForm},
-    'deleteInTrash':{name:'영구삭제',auth:'Update',rightMenu: false,icon:'deleteBtn',clickEvent: CommonFnUtil.onClickDeleteInTrash},
-    'restore':{name:'복원',auth:'Update',rightMenu: false,icon:'ActionReName',clickEvent: CommonFnUtil.onClickRestore},
-    'relatedDoc':{name:'연관문서',auth: 'Read',rightMenu: false,icon: 'ActionRelateDoc',clickEvent: CommonFnUtil.onClickRelatedDoc},
-    'setViewOnly':{name:'읽기 전용 설정',auth:'Update',rightMenu: false,icon:['ActionSetViewOnlyOFF', 'ActionSetViewOnlyON'],clickEvent: CommonFnUtil.onClickSetViewOnly},
-    'setPassword':{name:'보안설정', auth:'Read',rightMenu: true,icon:'ActionSetPW',clickEvent: CommonFnUtil.onClickSetPassword},
-    'setTag':{name:'태그설정', auth:'Read',rightMenu: false,icon:'docTag',clickEvent: CommonFnUtil.onClickSetTag},
-    'docDetailInfo':{name:'문서상세정보', auth:'Read',rightMenu: true,icon:'ActionInfo',clickEvent: CommonFnUtil.onClickDetailDocInfo},
-    'docInfo':{name:'문서정보', auth:'Read',rightMenu: false,icon:'ActionInfo',clickEvent: CommonFnUtil.onClickDocInfo},
-    'docHistory':{name:'문서이력', auth:'Read',rightMenu: false,icon:'ActionInfo',clickEvent: CommonFnUtil.onClickDocHistory},
-    'openLink' : { name: '오픈링크', icon: 'OpenLink', rightItem : true, menuEvent: CommonFnUtil.onClickOnOffLink},
-    'openLinkRead' : { name: '읽기', icon: '', value: 'R', rightItem : false, menuEvent: CommonFnUtil.onChangeOpenAuth},
-    'openLinkUpdate' : { name: '수정', icon: '', value: 'U', rightItem : false, menuEvent: CommonFnUtil.onChangeOpenAuth},
-    'groupNuserShare' : { name: '부서/사용자 공유', icon: 'ActionGroupNUserShare', rightItem : true, menuEvent: CommonFnUtil.onChangeOpenAuth},
+    'share':{name:'원커넥트',auth: 'Read',rightMenu: true, folderMenu: true, icon:'ActionShare',clickEvent: CommonFnUtil.onClickShare},
+    'linkCopy':{name:'링크복사',auth:'Read',rightMenu: false, folderMenu: false, icon:'ActionLinkCopy',clickEvent: CommonFnUtil.linkCopyEvent},
+    'ONECHAMBER(PDF)':{name:'PDF', auth:'Read',rightMenu: false, folderMenu: false, icon:'ActionOneSave',clickEvent: CommonFnUtil.onClickOneChamberSave},
+    'move':{name:'이동',auth: 'Read',rightMenu: false, folderMenu: true, icon:'ActionMove',clickEvent: CommonFnUtil.onClickMoveOpen},
+    'copy':{name:'사본 만들기',auth:'Update',rightMenu: false, folderMenu: false, icon:'ActionCopy',clickEvent: CommonFnUtil.onClickCopy},
+    'changeName':{name:'이름 변경', auth:'Read',rightMenu: false, folderMenu: true, icon:'ActionReName',clickEvent: CommonFnUtil.onClickRename},
+    'addOwnForm':{name:'나만의 양식 추가',auth: 'Read',rightMenu: false,folderMenu: false, icon:'ActionSetViewOnlyOFF',clickEvent: CommonFnUtil.onClickAddOwnForm},
+    'deleteInTrash':{name:'영구삭제',auth:'Update',rightMenu: false, folderMenu: false, icon:'deleteBtn',clickEvent: CommonFnUtil.onClickDeleteInTrash},
+    'restore':{name:'복원',auth:'Update',rightMenu: false, folderMenu: false, icon:'ActionReName',clickEvent: CommonFnUtil.onClickRestore},
+    'relatedDoc':{name:'연관문서',auth: 'Read',rightMenu: false, folderMenu: false, icon: 'ActionRelateDoc',clickEvent: CommonFnUtil.onClickRelatedDoc},
+    'setViewOnly':{name:'읽기 전용 설정',auth:'Update',rightMenu: false, folderMenu: false, icon:['ActionSetViewOnlyON', 'ActionSetViewOnlyOFF'],clickEvent: CommonFnUtil.onClickSetViewOnly},
+    'setPassword':{name:'보안설정', auth:'Read',rightMenu: true, folderMenu: false, icon:'ActionSetPW',clickEvent: CommonFnUtil.onClickSetPassword},
+    'setTag':{name:'태그설정', auth:'Read',rightMenu: false, folderMenu: false, icon:'docTag',clickEvent: CommonFnUtil.onClickSetTag},
+    'docDetailInfo':{name:'문서상세정보', auth:'Read',rightMenu: true, folderMenu: false, icon:'ActionInfo',clickEvent: CommonFnUtil.onClickDetailDocInfo},
+    'docInfo':{name:'문서정보', auth:'Read',rightMenu: false, folderMenu: false, icon:'ActionInfo',clickEvent: CommonFnUtil.onClickDocInfo},
+    'docHistory':{name:'문서이력', auth:'Read',rightMenu: false, folderMenu: false, icon:'ActionInfo',clickEvent: CommonFnUtil.onClickDocHistory},
+    'openLink' : { name: '오픈링크', icon: 'OpenLink', rightItem : true, folderMenu: false, menuEvent: CommonFnUtil.onClickOnOffLink},
+    'openLinkRead' : { name: '읽기', icon: '', value: 'R', rightItem : false, folderMenu: false, menuEvent: CommonFnUtil.onChangeOpenAuth},
+    'openLinkUpdate' : { name: '수정', icon: '', value: 'U', rightItem : false, folderMenu: false, menuEvent: CommonFnUtil.onChangeOpenAuth},
+    'groupNuserShare' : { name: '부서/사용자 공유', icon: 'ActionGroupNUserShare', rightItem : true, folderMenu: false, menuEvent: CommonFnUtil.onChangeOpenAuth},
 };
 
 const ActionMenu = () => {
@@ -77,6 +77,8 @@ const ActionMenu = () => {
             setIsActionMenu, 
             setAlertDialog,
             sortMenuState,
+            swipeItemState,
+            setSwipeItem,
             selectedTargetState } = useContext(CommonContext);
 
     // const [ clickMenu, setClickMenu] = useState([]);
@@ -109,7 +111,20 @@ const ActionMenu = () => {
     };
 
     const searchClickMenu = () => {
-        setOptions( renderMoreMenu( menus.length === 0 ? moreMenus : menus));
+        const folderMenus: any = [];
+        const folderMoreMenus: any = myDocMenuInfo.forEach(( menu:any) => {
+            // if( menu.folderMenu){
+            //     folderMenus.push( menu.)
+            // }
+            console.log( menu)
+        });
+
+        setOptions( 
+            renderMoreMenu( menus.length === 0 
+                            ? selectedTargetState.selectedTarget?.doc_type === "0" ? folderMoreMenus : moreMenus 
+                            : menus
+            )
+        );
     }
 
     // const renderMoreMenu = ( clickMenu:any) => {
@@ -167,6 +182,7 @@ const ActionMenu = () => {
             
             return newArray;
         };
+
         let menus = division( clickMenu, 4);
 
         let options:any = [];
@@ -181,7 +197,7 @@ const ActionMenu = () => {
                                 { !CommonUtil.strIsNull( myDocMenuInfo[menus[i][j]].icon) &&
                                     <View style={ moreMenuStyles.menuItemContainer}>
                                         { myDocMenuInfo[menus[i][j]].name === '읽기 전용 설정' ?
-                                            <SvgIcon name={ selectedTargetState.selectedTarget?.readonly ? myDocMenuInfo[menus[i][j]].icon[1] : myDocMenuInfo[menus[i][j]].icon[0]} width={20} height={20}/>
+                                            <SvgIcon name={ selectedTargetState.selectedTarget?.readonly ? myDocMenuInfo[menus[i][j]].icon[0] : myDocMenuInfo[menus[i][j]].icon[1]} width={20} height={20}/>
                                             :
                                             <SvgIcon name={ myDocMenuInfo[menus[i][j]].icon} width={20} height={20}/>
                                         }
@@ -265,8 +281,15 @@ const ActionMenu = () => {
                 const docUID = selectedTargetState.selectedTarget.docUID;
                 const isReadOnly = !selectedTargetState.selectedTarget.readonly ? 1 : 0;
 
-                CommonFnUtil.setReadOnly( docUID, isReadOnly);
-                    
+                const result = CommonFnUtil.setReadOnly( docUID, isReadOnly);
+                
+                setTimeout(() =>{
+                    setSwipeItem({
+                        ...swipeItemState,
+                        setReadOnly: result,
+                    });
+                }, 1000);
+
                 setOptions( []);
                 hiddenActionMenu();
 

--- a/src/utils/CommonFnUtil.tsx
+++ b/src/utils/CommonFnUtil.tsx
@@ -415,6 +415,8 @@ export default class CommonFnUtil{
     }
 
     public static setReadOnly = async( docUID: any, isReadOnly: any) => {
+        let result: boolean = false;
+
         const data: any = {
             protocolId : 'P620',
             data: {"docUID": docUID, "readonly": isReadOnly},
@@ -422,6 +424,8 @@ export default class CommonFnUtil{
 
         await Adapter.fetch.protocol(data).then((res) => {
             if( res) {
+                result = isReadOnly ? true : false ;
+
                 Toast.show({
                     type: 'success',
                     text1: isReadOnly ? '읽기 전용로 설정되었습니다.' : '읽기 전용이 해제되었습니다.',
@@ -438,7 +442,7 @@ export default class CommonFnUtil{
             });
         })
 
-        return;
+        return result;
     }
 
     public static searchDataList = async( sendata : any) => {


### PR DESCRIPTION
1. 더보기 메뉴(ActionMenu.tsx가 최상위 컴포넌트에 선언되어 계속 띄워져있음)에서 읽기 모드 설정 시, 상태 값이 바뀌지 않는 오류 수정
 - 기존: Actionmenu.tsx 에서 useState 로 상태 값 관리 > 더보기 버튼 클릭 시, 현재 선택된 문서 정보의 읽기 상태 값으로 표시
 - 개선: Context API 사용하여, 상태 값 관리하는 공통 변수 생성 및 상태 값 관리 > 현재 선택된 문서 정보의 읽기 값으로 상태 표시되도록 수정