### PR TITLE
22/11/28(Mon) 개발 건

### DIFF
--- a/src/component/CommonAccordion.tsx
+++ b/src/component/CommonAccordion.tsx
@@ -15,46 +15,45 @@ const CommonAccordion = ( ) => {
         data: [],
     });
 
-    useLayoutEffect(() => {
+    useEffect(() => {
+        const getDocHistory = async( docUID: any) => {
+            let result: any = [];
+    
+            const data: any = {
+                protocolId : 'P538',
+                data : {
+                    docUID: docUID,
+                    targetObjectType:'DO',
+                    termValue :'Y',					
+                }
+            };
+    
+            await Adapter.fetch.protocol( data).then((res) =>{
+                if( res) {
+                    result = res.list;
+    
+                    setIsResultData({
+                        ...isResultData,
+                        data: result
+                    });
+                }
+            }).catch((error) => {
+                console.log( error);
+            })
+            return result;
+        };
+       
         if( isResultData.data?.length === 0) {
             getDocHistory( selectedTargetState.selectedTarget?.docUID);
         }
-      });
+    }, []);
     
     useEffect(() => {
         if( !isResultData.isSetClear && isResultData.data.length > 0 ) {
             getDocHistoryContent();
         }
-
     }, [ isResultData]);
 
-    const getDocHistory = async( docUID: any) => {
-        let result: any = [];
-
-        const data: any = {
-            protocolId : 'P538',
-            data : {
-                docUID: docUID,
-                targetObjectType:'DO',
-                termValue :'Y',					
-            }
-        };
-
-        await Adapter.fetch.protocol( data).then((res) =>{
-            if( res) {
-                result = res.list;
-
-                setIsResultData({
-                    ...isResultData,
-                    data: result
-                });
-            }
-        }).catch((error) => {
-            console.log( error);
-        })
-        return result;
-    };
-   
     const convertHistoryData = ( _obj : any) => {
         let _iconUrl = "";
         let _action_name ="";
@@ -182,11 +181,9 @@ const CommonAccordion = ( ) => {
       }
       
       const getDocHistoryContent = () => {
-      
           const docHistoryData = isResultData.data;
-          
+
           let dayGroupLists = [];
-      
           for( let i =0; i < docHistoryData.length; i++) {
             let isDataInclude = false;
       
@@ -206,7 +203,6 @@ const CommonAccordion = ( ) => {
                 isDataInclude = true;
               }
             }
-      
             if(!isDataInclude) dayGroupLists.push(addHistoryDataObj);      
           }
       
@@ -279,28 +275,21 @@ const CommonAccordion = ( ) => {
 
       const [ expanded, setExpanded] = useState( false);
               
-      const handlePress = () => setExpanded(!expanded);
+      const handlePress = () => {
+        alert( expanded);
+        setExpanded( !expanded);
+      }
               
 
       return useMemo(() => (
         isResultData.isSetClear && isResultData.data.length > 0 &&
-            // <List.AccordionGroup>
-            //     {/* { isResultData.data.map(( data: any, index: number) => {
-            //         return (
-            //                 <List.Accordion title={ data.month} id={ data.month + index}>
-            //                     <List.Item title={ getListItemContent.bind(this, data)} />
-            //                 </List.Accordion>
-            //             )
-            //         })
-            //     } */}
-            // </List.AccordionGroup>
-            <List.Section style={{ borderWidth:1, width:'100%', height:'100%'}}>
+            <List.Section style={{ borderWidth:1, width:'95%', height:'90%', padding:5}}>
                 { isResultData.data.map(( data: any) => {
                     return (
                             <List.Accordion
                                 title={ data.month}
-                                id={ data.date}
-                                // left={props => <List.Icon {...props} icon="folder" />}
+                                id={ data.month + data.date}
+                                left={ props => <List.Icon {...props} icon="folder" />}
                                 expanded={ expanded}
                                 onPress={ handlePress}
                                 style={{ borderWidth:1, borderColor:'pink', marginBottom:10, backgroundColor:'#fff',}}
@@ -310,23 +299,34 @@ const CommonAccordion = ( ) => {
                                     description="Item description"
                                     left={props => <List.Icon {...props} icon="folder" style={{ width:'100%', height:80, borderWidth:1, backgroundColor:'#fff',}}/>}
                                 /> */}
-                            <View style={{ borderWidth:1, borderColor:'red',height:200,}}>
-                                { data.history.map(( dayHistory: any) => {
-                                        <List.Item key={ data.date} title={ dayHistory.name + dayHistory.action} description={ data.date} style={{ width:'100%', height:80, borderWidth:1, backgroundColor:'#fff',}}  />
-                                    })
-                                }
-                            </View>
+                                {/* <View style={{ borderWidth:1, borderColor:'red',height:150,marginBottom:10}}> */}
+                                    { data.history.map(( dayHistory: any) => {
+                                           return <List.Item key={ data.date} title={ dayHistory.name + dayHistory.action} description={ data.date} style={{ width:'100%', height:80, borderWidth:1, backgroundColor:'#fff',}}  />
+                                        })
+                                    }
+                                {/* </View> */}
                                 {/* <List.Item title={ getListItemContent.bind(this, data)} /> */}
                             </List.Accordion>
                         )
                     })
-                }                
+                }
             </List.Section>
               
       ), [ isResultData]);
 };
 
 export default CommonAccordion;
+
+// <List.AccordionGroup>
+//     {/* { isResultData.data.map(( data: any, index: number) => {
+//         return (
+//                 <List.Accordion title={ data.month} id={ data.month + index}>
+//                     <List.Item title={ getListItemContent.bind(this, data)} />
+//                 </List.Accordion>
+//             )
+//         })
+//     } */}
+// </List.AccordionGroup>
 
 
 

--- a/src/component/CommonFlatList.tsx
+++ b/src/component/CommonFlatList.tsx
@@ -130,7 +130,7 @@ const CommonFlatList = ( props: FlatListProps) => {
                 setSwipeItem({
                     ...swipeItemState,
                     setFavorite: resultData,
-                })
+                });
             }, (1000));
         }
         else {

--- a/src/content/FavoriteDoc.tsx
+++ b/src/content/FavoriteDoc.tsx
@@ -1,5 +1,5 @@
-import React, { useContext, useState, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
-import { View, Text, SafeAreaView, ScrollView} from 'react-native';
+import React, { useContext, useState, useEffect, useMemo, useRef, useCallback } from 'react';
+import { View, Text, SafeAreaView} from 'react-native';
 import { CommonHeader} from '../component/header/index';
 import CommonDocBoxList from '../component/docBoxList/CommonDocBoxList';
 import { MyDocStyles} from './style/style';
@@ -79,13 +79,12 @@ const FavoriteDoc = ( props : any) => {
         'TrashDoc': false,
     });
 
-    //딱 한번 실행 됌 
-    useLayoutEffect( () => {
+    useEffect(() => {
+        //정렬 메뉴 & 폴더 경로 셋팅
         if( CommonUtil.strIsNull( sortMenuState.contextName) || sortMenuState.contextName !== CONTEXT_NAME) {
             setSortMenu( CONTEXT_NAME, { sortItem:'1', fileTypes:'', sortOrder:'d'}, FavoriteDocMenuInfo[ 'sortMenu'])
-            setTargetFullPath( [''], ['중요문서함'], null)
+            setTargetFullPath( [''], ['중요문서함'], null);
         }
-
     }, []);
 
     useEffect(() => {
@@ -121,19 +120,19 @@ const FavoriteDoc = ( props : any) => {
         }
     }, [ swipeItemState]);
 
-    const ViewModeCheck = () => {
+    const ViewModeCheck = useCallback(() => {
         setListViewMode( !listViewMode);
-    };
+    }, [ listViewMode]);
 
-    const onEndReached = async() => {
+    const onEndReached = useCallback(() => async() => {
         if( isLoading) {
             return;
         }
         else {
             setLoading(true);
-            // setDataList({...reqListData, pageNum: reqListData.pageNum + 1});
+            setDataList({...reqListData, pageNum: reqListData.pageNum + 1});
         }
-    };
+    }, [ isLoading]); 
     
     return useMemo(() => (
         <>

--- a/src/content/TrashDoc.tsx
+++ b/src/content/TrashDoc.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+import React, { useContext, useState, useEffect, useLayoutEffect, useMemo, useRef, useCallback } from 'react';
 import { View, Text, SafeAreaView} from 'react-native';
 import { CommonHeader} from '../component/header/index';
 import CommonDocBoxList from '../component/docBoxList/CommonDocBoxList';
@@ -67,8 +67,8 @@ const TrashDoc = ( props : any) => {
         'TrashDoc': true,
     });
 
-    //딱 한번 실행 됌 
-    useLayoutEffect( () => {
+    useEffect(() => {
+        //정렬 메뉴 & 폴더 경로 셋팅
         if( CommonUtil.strIsNull( sortMenuState.contextName) || sortMenuState.contextName !== CONTEXT_NAME) {
             setSortMenu( CONTEXT_NAME, { sortItem:'6', fileTypes:'', sortOrder:'d'}, trashDocMenuInfo[ 'sortMenu']);
         }
@@ -91,19 +91,19 @@ const TrashDoc = ( props : any) => {
         }
     }, [ alertDialogState.alertName]);
 
-    const ViewModeCheck = () => {
+    const ViewModeCheck = useCallback(() => {
         setListViewMode( !listViewMode);
-    };
+    }, [ listViewMode]);
 
-    const onEndReached = async() => {
+    const onEndReached = useCallback(() => async() => {
         if( isLoading) {
             return;
         }
         else {
             setLoading(true);
-            // setDataList({...reqListData, pageNum: reqListData.pageNum + 1});
+            setDataList({...reqListData, pageNum: reqListData.pageNum + 1});
         }
-    }
+    }, [ isLoading]); 
     
     return useMemo(() => (
         <>

--- a/src/dialog/DocHistory.tsx
+++ b/src/dialog/DocHistory.tsx
@@ -2,7 +2,8 @@ import React, { useMemo, useState } from 'react';
 import { View,} from 'react-native';
 import { dialogStyles} from './style/style';
 import CommonHeader from '../component/header/CommonHeader';
-import CommonCollapsible from '../component/CommonCollapsible';
+import CommonAccordion from '../component/CommonAccordion';
+// import CommonCollapsible from '../component/CommonCollapsible';
 
 const CONTEXT_NAME = 'DocHistory';
 const copyDialogHeaderInfo : any = {
@@ -29,7 +30,7 @@ export const DocHistory = () => {
                 sortMenu ={ null}
             />
 
-            <CommonCollapsible isActiveStateNM = {'DocHistory'} isActiveAccordion={ isActiveAccordion} setIsActiveAccordion={ setIsActiveAccordion}/>
+            <CommonAccordion />
 
         </View>
     ), [ isActiveAccordion])

--- a/src/dialog/DocInfoDialog.tsx
+++ b/src/dialog/DocInfoDialog.tsx
@@ -48,7 +48,6 @@ export const DocInfoDialog = () => {
         }
 
         setDocInfoArr([
-            ...docInfoArr,
             { name: '소유자', value: selectedTargetState.selectedTarget.creatorName},
             { name: '문서 제목', value: selectedTargetState.selectedTarget.doc_name},
             { name: '문서 타입', value: selectedTargetState.selectedTarget.file_type === 'O' ? 'ONEFFICE 문서' : 'ONEFFICE 프레젠테이션'},

--- a/src/dialog/copyDialog.tsx
+++ b/src/dialog/copyDialog.tsx
@@ -89,14 +89,15 @@ export const CopyDialog = () => {
     }; 
 
 
-    const onEndReached = () => {
+    const onEndReached = useCallback(() => {
         if( isLoading) {
             return;
         }else {
             setLoading( true);
             setDataList({...reqListData, pageNum: reqListData.pageNum + 1});
         }
-    };
+    }, [ isLoading]);
+    
     return useMemo(() => (
         <View style={dialogStyles.container}>
             <CommonHeader 

--- a/src/list/DefaultListItem.tsx
+++ b/src/list/DefaultListItem.tsx
@@ -2,7 +2,6 @@ import React, { useContext, useMemo} from 'react';
 import {View, Text, TouchableOpacity} from 'react-native';
 import { MyDocListViewStyles} from '../content/style/style';
 import SvgIcon from '../component/svgIcon/SvgIcon';
-import { TouchableHighlight } from 'react-native-gesture-handler';
 import { CommonContext } from '../context/CommonContext';
 import Toast from 'react-native-toast-message';
 
@@ -69,9 +68,9 @@ const DefaultListItem = ( props:any) => {
                        <View style={ MyDocListViewStyles.docInfo}>
                            <Text style={ MyDocListViewStyles.title} numberOfLines={1}>{ props.data.doc_name}</Text>
                            <View style={{ flexDirection:'row', marginTop:3}}>
-                               <View style={{ flexDirection:'row', alignItems:'center',}}>
+                               <View style={{ flexDirection:'row', alignItems:'center'}}>
                                     { props.data.share_type === 1 ? 
-                                        <SvgIcon name = "docShareSend" width={13} height={13} style={{ marginRight:2}}/> 
+                                        <SvgIcon name = "docShareSend" width={13} height={13} /> 
                                     : 
                                     props.data.share_type === 2 ? 
                                         <SvgIcon name = "docShareReceive" width={13} height={13}/>
@@ -79,7 +78,9 @@ const DefaultListItem = ( props:any) => {
                                     }
                                     { props.data.flagOpenLink && <SvgIcon name = "docOpenLink" width={13} height={13} /> }
                                     { props.data.important && <SvgIcon name = "docFavorite" width={13} height={13} /> }
+                                    {(props.data && Number(props.data.commentCount) > 0) && <SvgIcon name = "docComment" width={13} height={13} /> }
                                     { props.data.security_key && <SvgIcon name = "docSecurity" width={13} height={13} /> }
+                                    { props.data.readonly && <SvgIcon name = "docSecurity" width={13} height={13} /> }
                                </View>
                                 { sortMenuState && sortMenuState.contextName !== 'TrashDoc' 
                                     ? <Text style={ MyDocListViewStyles.text}> { props.data.mod_name} {'|'} { props.data.mod_date}</Text>
@@ -98,11 +99,11 @@ const DefaultListItem = ( props:any) => {
                </TouchableOpacity>
                
                { !props.fullpath ?
-                       <TouchableHighlight onPress={ onClickActionMenu}>
+                       <TouchableOpacity onPress={ onClickActionMenu}>
                            <View>
                                <SvgIcon name="DocMoreBtn" width={22} height={22}/>
                            </View> 
-                       </TouchableHighlight>
+                       </TouchableOpacity>
                    :
                     <View></View>
                }

--- a/src/menu/SortPopOver.tsx
+++ b/src/menu/SortPopOver.tsx
@@ -79,7 +79,7 @@ const SortPopOver = (props: any) => {
         }
 
         setShowPopover(false);
-        setSortMenu( sortMenuState.contextName, { sortItem:sortItem, fileTypes:fileTypes, sortOrder:sortOrder}, sortMenuState.sortMenuInfo)
+        setSortMenu( sortMenuState.contextName, { sortItem:sortItem, fileTypes:fileTypes, sortOrder:sortOrder}, sortMenuState.sortMenuInfo);
     }
 
     const renderPopOverTitle = useCallback(() => {


### PR DESCRIPTION
1. 문서이력 react-native-paper > List.Accordion lib 적용
 - 중요문서함 > 카테고리 영역과 같이 쓰기 위해 추가 작업 필요 (기존: react-native-collapsible/accordion 라이브러리 미사용)
 - title 클릭 시, 영역 접히고 닫히는 부분 동작되지 않는 오류 수정 필요
2. 각 문서함 별, 1) 리스트 보기 모드 함수, 2) scroll End 시점 새 문서 리스트 불러오는 함수 재사용하도록 useCallback hook 적용
3. 문서정보 리스트 렌더링 시점마다 계속 추가되는 오류 수정( set함수 실행 시, 이전 값을 유지시킨 채 계속 추가해서 발생된 오류)