### PR TITLE
22/12/15(Wed) 개발

### DIFF
--- a/src/component/CommonDialogToast.tsx
+++ b/src/component/CommonDialogToast.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import Toast, { BaseToast, ErrorToast} from 'react-native-toast-message';
+
+const toastConfig = {
+    success: ( props : any) => (
+        <BaseToast 
+            {...props}
+            style={{ borderLeftColor: 'pink' }}
+            contentContainerStyle={{ paddingHorizontal: 15 }}
+            text1Style={{
+              fontSize: 15,
+              fontWeight: '400'
+            }}
+        />
+    ),
+
+    error: ( props : any) => (
+        <ErrorToast
+            {...props}
+            style={{ borderLeftColor: 'red' }}
+            contentContainerStyle={{ paddingHorizontal: 15 }}
+            text1Style={{
+            fontSize: 15,
+            fontWeight: '400'
+            }}
+        />
+    ),
+};
+
+export const CommonDialogToast = () => {
+    return (
+        <Toast config={ toastConfig} />
+    )
+}

--- a/src/dialog/SecurityDialog.tsx
+++ b/src/dialog/SecurityDialog.tsx
@@ -1,10 +1,11 @@
-import React, { useContext, useMemo } from 'react';
-import { View, Text } from 'react-native';
-import { TextInput} from 'react-native-paper';
+import React, { useContext, useEffect, useState } from 'react';
+import { View, StyleSheet, TouchableOpacity } from 'react-native';
+import { RadioButton, Text, TextInput} from 'react-native-paper';
 import { dialogStyles} from './style/style';
 import CommonHeader from '../component/header/CommonHeader';
 import { CommonContext } from '../context/CommonContext';
-import CommonFnUtil from '../utils/CommonFnUtil';
+import Toast from 'react-native-toast-message';
+import { CommonDialogToast} from '../component/CommonDialogToast';
 
 const CONTEXT_NAME = 'SecurityDialog';
 const securityDialogHeaderInfo : any = {
@@ -18,8 +19,42 @@ const securityDialogHeaderInfo : any = {
     },
 };
 
+/**
+ * 설정: 암호 & 암호 확인
+ * 변경: 현재암호/ 암호/ 암호확인
+ * 해제: 현재 암호만 활성화
+ */
+
+const radioBtnValues = [ { text: '설정', value: 'setting'}, { text: '변경', value: 'change'}, { text: '해제', value: 'unSetting'}];
+const txtInputValue =[ '현재 암호','암호','암호 확인'];
+const pwErrors = [
+    {
+        'previousPW': ['※4자 이상 20자 이하로 입력해주세요.','※현재암호와 일치하지않습니다.'], //현재 암호
+        'currentPW': ['※4자 이상 20자 이하로 입력해주세요.','※현재암호와 동일한 암호는 사용하실 수 없습니다.'], //암호
+        'doubleChkPW': ['※입력한 암호와 일치하지 않습니다.','※새 암호와 일치하지 않습니다.'], //암호 확인
+    }
+];
+
 export const SecurityDialog = () => {
     const { selectedTargetState} = useContext( CommonContext);
+    const [ value, setValue] = useState('setting');
+    const [ password, setPassword] = useState({
+        previousPW: '',
+        currentPW: '',
+        doubleChkPW: '',
+    });
+
+    useEffect(() => {
+        //비밀번호 값 비교하는 수식 필요
+
+        // Toast.show({
+        //     type:'success',
+        //     text1: '이동되었습니다.',
+        //     visibilityTime: 1000,
+        //     autoHide: true
+        // });
+
+    }, [ password]);
 
     return (
         <View style={dialogStyles.container}>
@@ -36,6 +71,61 @@ export const SecurityDialog = () => {
                 sortMenu ={ null}
             />
 
+            <View style={{ borderWidth:1, borderColor:'red', width:'100%', height:'90%'}}>
+                <RadioButton.Group onValueChange={ newValue => setValue( newValue)} value={ value}>
+                    <View style={ sctyDialogStyle.sctyMenuRow}>
+                        <Text>문서보안설정</Text>
+                        { radioBtnValues.map( value => {
+                            return (
+                                <View style={{ flexDirection:'row', alignItems:'center', marginLeft:10}}>
+                                    <RadioButton value={ value.value}/>
+                                    <Text>{ value.text}</Text>
+                                </View>
+                            )
+                        })}
+                    </View>
+                </RadioButton.Group>
+
+                { txtInputValue.map( txt => {
+                    return (
+                        <View style={ sctyDialogStyle.sctyMenuRow}>
+                            <Text style={{ width:80}}>{ txt}</Text>
+                            <TextInput 
+                                value={  txt === '암호' ? password.currentPW : password.doubleChkPW}
+                                onChangeText={ value => setPassword({
+                                    ...password,
+                                    currentPW: txt === '암호' ? value : password.currentPW,
+                                    doubleChkPW: txt === '암호 확인' ? value : password.doubleChkPW
+                                })}    
+                                style={ sctyDialogStyle.textInput}
+                            />
+                        </View>
+                    )
+                })}
+
+                <View style={{ width:'100%', height:60, padding:10, marginTop:10}}>
+                    <Text style={{ fontSize:12, color:'red'}}>주의: 암호를 잊으면 문서를 복구할 수 없습니다.</Text>
+                    <Text style={{ marginTop:5, fontSize:12, color:'red'}}>암호는 대소문자를 구분하며, 4자 이상 20자 이하로 입력 가능 합니다.</Text>
+                </View>
+            </View>
+            <CommonDialogToast />
         </View>
     )
 }
+
+const sctyDialogStyle = StyleSheet.create({
+    sctyMenuRow: {
+        width:'100%', 
+        height:60, 
+        flexDirection:'row', 
+        alignItems:'center', 
+        paddingLeft:10, 
+        paddingRight:10,
+        borderBottomWidth:1,
+    },
+    textInput: {
+        width:'70%', 
+        height: 40, 
+        backgroundColor:'#fff'
+    }
+})

--- a/src/dialog/TagDialog.tsx
+++ b/src/dialog/TagDialog.tsx
@@ -5,6 +5,8 @@ import { dialogStyles} from './style/style';
 import CommonHeader from '../component/header/CommonHeader';
 import { CommonContext } from '../context/CommonContext';
 import CommonFnUtil from '../utils/CommonFnUtil';
+import Toast from 'react-native-toast-message';
+import { CommonDialogToast} from '../component/CommonDialogToast';
 
 const CONTEXT_NAME = 'TagDialog';
 const tagDialogHeaderInfo : any = {
@@ -95,6 +97,7 @@ export const TagDialog = () => {
                 <Text style={{ height:30, paddingTop:3}}>{ tagDescription.get(3)}</Text>
                 <Text style={{ height:40, paddingTop:3, display:'flex', flexWrap: 'wrap' }}>{ tagDescription.get(4)}</Text>
             </View>
+            <CommonDialogToast />
         </View>
     ), [ isTagDataLists, tagValue]); 
 }

--- a/src/utils/CommonFnUtil.tsx
+++ b/src/utils/CommonFnUtil.tsx
@@ -813,7 +813,7 @@ export default class CommonFnUtil{
     }
     public static onClickSetPassword = async() => {
         // console.log(' onClickCategory');
-        return 'newWindow|SetPasswordDialog';
+        return 'newWindow|SecurityDialog';
     }
     
     public static onClickRelatedDoc = async() => {


### PR DESCRIPTION
1. Modal 위에서 react-native-toast-message lib 의 Toast 태그가 뜨지 못하는 오류 수정
  문제 > root view 위에 toast 가 띄워진 상태여서, 자식 컴포넌트인 modal 위로 띄울 수가 없음
  해결 > 모달 내부에 tast component 생성해서 사용
   - commonDialogToast.tsx 파일 추가
   - TagDialog.tsx 도 추후에 처리 필요(임시 작업해둠)

2. 보안설정 UI 그리는 작업 진행(40%) 임시커밋
 - react-native-paper lib 내 radiobutton, Text 사용
 - 암호 값 비교하여 에러메시지 뿌려주는 함수 생성 필요
 - 문서보안 설정 값에 따라 textInput 어떻게 뿌려줄 지 고민 필요