### PR TITLE
22/12/15(Thur) 개발

### DIFF
--- a/src/dialog/SecurityDialog.tsx
+++ b/src/dialog/SecurityDialog.tsx
@@ -1,10 +1,9 @@
-import React, { useContext, useEffect, useState } from 'react';
-import { View, StyleSheet, TouchableOpacity } from 'react-native';
+import React, { useContext, useState } from 'react';
+import { View, StyleSheet } from 'react-native';
 import { RadioButton, Text, TextInput} from 'react-native-paper';
 import { dialogStyles} from './style/style';
 import CommonHeader from '../component/header/CommonHeader';
 import { CommonContext } from '../context/CommonContext';
-import Toast from 'react-native-toast-message';
 import { CommonDialogToast} from '../component/CommonDialogToast';
 
 const CONTEXT_NAME = 'SecurityDialog';
@@ -25,39 +24,27 @@ const securityDialogHeaderInfo : any = {
  * 해제: 현재 암호만 활성화
  */
 
-const radioBtnValues = [ { text: '설정', value: 'setting'}, { text: '변경', value: 'change'}, { text: '해제', value: 'unSetting'}];
-const txtInputValue =[ '현재 암호','암호','암호 확인'];
-const pwErrors = [
-    {
-        'previousPW': ['※4자 이상 20자 이하로 입력해주세요.','※현재암호와 일치하지않습니다.'], //현재 암호
-        'currentPW': ['※4자 이상 20자 이하로 입력해주세요.','※현재암호와 동일한 암호는 사용하실 수 없습니다.'], //암호
-        'doubleChkPW': ['※입력한 암호와 일치하지 않습니다.','※새 암호와 일치하지 않습니다.'], //암호 확인
-    }
-];
+const radioBtnValues = [{ text: '변경', value: 'change'}, { text: '해제', value: 'unSetting'}];
 
 export const SecurityDialog = () => {
     const { selectedTargetState} = useContext( CommonContext);
-    const [ value, setValue] = useState('setting');
-    const [ password, setPassword] = useState({
+    const [ value, setValue] = useState( selectedTargetState.selectedTarget.security_key ? 'change' : ''); //문서보안설정 상태 값
+    const [ password, setPassword] = useState({ //비밀번호 상태 값
         previousPW: '',
         currentPW: '',
         doubleChkPW: '',
     });
+    const txtInputValue = selectedTargetState && selectedTargetState.selectedTarget.security_key ?
+                        ['현재 암호','새 암호','새 암호 확인']
+                     :
+                        ['암호','암호 확인'];
 
-    useEffect(() => {
-        //비밀번호 값 비교하는 수식 필요
-
-        // Toast.show({
-        //     type:'success',
-        //     text1: '이동되었습니다.',
-        //     visibilityTime: 1000,
-        //     autoHide: true
-        // });
-
-    }, [ password]);
+    const changeSettingMode = () => {
+        //변경, 해제 클릭 시, textinput ui 변경 필요
+    };
 
     return (
-        <View style={dialogStyles.container}>
+        <View style={[ dialogStyles.container, { height: 500}]}>
             <CommonHeader 
                 headerName = { '보안설정'}
                 multiSelectedState = { null}
@@ -71,34 +58,95 @@ export const SecurityDialog = () => {
                 sortMenu ={ null}
             />
 
-            <View style={{ borderWidth:1, borderColor:'red', width:'100%', height:'90%'}}>
-                <RadioButton.Group onValueChange={ newValue => setValue( newValue)} value={ value}>
-                    <View style={ sctyDialogStyle.sctyMenuRow}>
-                        <Text>문서보안설정</Text>
-                        { radioBtnValues.map( value => {
-                            return (
-                                <View style={{ flexDirection:'row', alignItems:'center', marginLeft:10}}>
-                                    <RadioButton value={ value.value}/>
-                                    <Text>{ value.text}</Text>
-                                </View>
-                            )
-                        })}
-                    </View>
-                </RadioButton.Group>
+            <View style={{ borderWidth:1, width:'100%', height:'100%',}}>
+                { selectedTargetState && selectedTargetState.selectedTarget.security_key && 
+                    <RadioButton.Group onValueChange={ newValue => setValue( newValue)} value={ value}>
+                        <View style={ sctyDialogStyle.sctyMenuRow}>
+                            <Text>문서보안설정</Text>
+                            { radioBtnValues.map( (value, index) => {
+                                return (
+                                    <View key={ value.value} style={{ flexDirection:'row', alignItems:'center', marginLeft:10}}>
+                                        <RadioButton value={ value.value} status= "checked" onPress={ changeSettingMode}/>
+                                        <Text>{ value.text}</Text>
+                                    </View>
+                                )
+                            })}
+                        </View>
+                    </RadioButton.Group>
+                }
 
                 { txtInputValue.map( txt => {
                     return (
-                        <View style={ sctyDialogStyle.sctyMenuRow}>
+                        <View style={[ sctyDialogStyle.sctyMenuRow, ( password.previousPW !== '' || password.currentPW !== '' || password.doubleChkPW !== '') && sctyDialogStyle.sctyMenuRowErrorOn]} key={ txt}>
                             <Text style={{ width:80}}>{ txt}</Text>
-                            <TextInput 
-                                value={  txt === '암호' ? password.currentPW : password.doubleChkPW}
-                                onChangeText={ value => setPassword({
-                                    ...password,
-                                    currentPW: txt === '암호' ? value : password.currentPW,
-                                    doubleChkPW: txt === '암호 확인' ? value : password.doubleChkPW
-                                })}    
-                                style={ sctyDialogStyle.textInput}
-                            />
+                            <View style={{ width:'100%'}}>
+                                { selectedTargetState.selectedTarget.security_key ?
+                                    <>
+                                        <TextInput 
+                                            value={  txt === '현재 암호' ? password.previousPW 
+                                                    : txt === '새 암호' ? password.currentPW 
+                                                    : password.doubleChkPW  
+                                            }
+                                            onChangeText={ value => setPassword({
+                                                previousPW: txt === '현재 암호' ? value : password.previousPW,
+                                                currentPW: txt === '새 암호' ? value : password.currentPW,
+                                                doubleChkPW: txt === '새 암호 확인' ? value : password.doubleChkPW
+                                            })}    
+                                            style={ sctyDialogStyle.textInput}
+                                            secureTextEntry
+                                            placeholder={ txt}
+                                            right={<TextInput.Icon icon="eye" />}
+                                        />
+                                        {( password.previousPW !== '' || password.currentPW !== '' || password.doubleChkPW !== '' ) &&
+                                            <View style={{ width:'100%', height:30, justifyContent:'center'}}>
+                                                {( password.previousPW !== '' && password.previousPW.length < 4 && txt === '현재 암호') &&
+                                                    <Text style={{ fontSize:12, color:'red'}}>※ 4자 이상 20자 이하로 입력해주세요.</Text>
+                                                }
+                                                {( password.currentPW !== '' && password.currentPW.length < 4 && txt === '새 암호') &&
+                                                    <Text style={{ fontSize:12, color:'red'}}>※ 4자 이상 20자 이하로 입력해주세요.</Text>
+                                                }
+                                                {( password.doubleChkPW !== '' && password.doubleChkPW.length < 4 && txt === '새 암호 확인') &&
+                                                    <Text style={{ fontSize:12, color:'red'}}>※ 4자 이상 20자 이하로 입력해주세요.</Text>
+                                                }
+                                                { password.previousPW !== '' && password.currentPW !== '' && txt === '새 암호' && password.previousPW === password.currentPW && 
+                                                    <Text style={{ fontSize:12, color:'red'}}>※ 현재암호와 동일한 암호는 사용하실 수 없습니다.</Text>
+                                                } 
+                                                { password.currentPW !== '' && password.doubleChkPW !== '' && txt === '새 암호 확인' && password.currentPW !== password.doubleChkPW && 
+                                                    <Text style={{ fontSize:12, color:'red'}}>※ 새 암호와 일치하지 않습니다.</Text>
+                                                } 
+                                            </View>
+                                        }
+                                    </>
+                                    :
+                                    <>
+                                        <TextInput 
+                                            value={  txt === '암호' ? password.currentPW : password.doubleChkPW}
+                                            onChangeText={ value => setPassword({
+                                                ...password,
+                                                currentPW: txt === '암호' ? value : password.currentPW,
+                                                doubleChkPW: txt === '암호 확인' ? value : password.doubleChkPW
+                                            })}    
+                                            style={ sctyDialogStyle.textInput}
+                                            secureTextEntry
+                                            placeholder={ txt}
+                                            right={<TextInput.Icon icon="eye" />}
+                                        />
+                                        { (password.currentPW !== '' || password.currentPW !== '' ) &&
+                                            <View style={{ width:250, height:35, justifyContent:'center'}}>
+                                                {( password.currentPW !== '' && password.currentPW.length < 4 && txt === '암호') &&
+                                                    <Text style={{ fontSize:12, color:'red'}}>※ 4자 이상 20자 이하로 입력해주세요.</Text>
+                                                }
+                                                {( password.doubleChkPW !== '' && password.doubleChkPW.length < 4 && txt === '암호 확인') &&
+                                                    <Text style={{ fontSize:12, color:'red'}}>※ 4자 이상 20자 이하로 입력해주세요.</Text>
+                                                }
+                                                { password.currentPW !== '' && password.doubleChkPW !== '' && txt === '암호 확인' && password.currentPW !== password.doubleChkPW && 
+                                                    <Text style={{ fontSize:12, color:'red'}}>※ 입력한 암호와 일치하지 않습니다.</Text>
+                                                } 
+                                            </View>
+                                        }
+                                    </>
+                                }
+                            </View>
                         </View>
                     )
                 })}
@@ -123,9 +171,12 @@ const sctyDialogStyle = StyleSheet.create({
         paddingRight:10,
         borderBottomWidth:1,
     },
+    sctyMenuRowErrorOn: {
+        height: 100,
+    },
     textInput: {
         width:'70%', 
         height: 40, 
-        backgroundColor:'#fff'
+        backgroundColor:'#fff',
     }
 })


### PR DESCRIPTION
1. 보안설정 UI ( 80%)
 - 문서보안설정 메뉴 변경
  > 기존: 설정/변경/해제
  > 개선: 변경/해제
  > 이유: 선택한 문서의 security 값이 없으면 
              1) 비밀번호 설정이 default 이고, 
              2) 비밀번호 변경을 위한 진입 시에 다시 비밀번호 설정할 필요가 없다고 판단
 - 선택된 문서보안설정 값 & 비밀번호 값의 상태 관리 용 useState 생성
 - 현재 문서의 security 값 유/무로 textinput text array 분기처리
 - 비밀번호 에러 메세지 노출 부분의 경우의 수 따져서 생성하는 로직 개선 필요(우선 작업 완료)

 > 보완해야할 부분
   1. 변경/해제 메뉴 클릭 시, textInput 의 상태 변경 필요(활성화/비활성화)
   2. 비밀번호 에러 메시지 노출 로직 개선할 방안 고민하기
   3. 에러메시지 노출하는 부분 UI 틀어지는 문제 검토 필요