### PR TITLE
22/12/19(Mon) 개발

### DIFF
--- a/src/component/header/CommonHeader.tsx
+++ b/src/component/header/CommonHeader.tsx
@@ -42,6 +42,8 @@ const CommonHeader = ( props: CommonHeaderInfo) => {
             setCenterDialog, 
             selectedTargetState} = useContext(CommonContext);
 
+    const [ headerDataInfos, password] = contextName === 'SecurityDialog' ? headerDataInfo : [];
+
     const onClickLeftBtn = ( iconName: any) => { // 문서함 뒤로가기 or 팝업 닫기 버튼
         if( iconName === 'UserInfoICon') {
             // navigation.openDrawer();
@@ -88,19 +90,44 @@ const CommonHeader = ( props: CommonHeaderInfo) => {
                     }, 300);
                     break;
 
+                case 'SecurityDialog':
+                    if( headerDataInfos.currErrorStatus){
+                        switch( headerDataInfos.currSelectedStatus) {
+                            case 'change':
+                            case 'unSetting':
+                                const nSettingType = headerDataInfos.currSelectedStatus === 'change' ? 1 : 2;
+                                resultData = CommonFnUtil.setSecurityPassword( selectedTargetState.selectedTarget.docUID, selectedTargetState.selectedTarget.folder_no,
+                                    nSettingType, password.previousPW, password.currentPW);
+                                break;
+                            case 'setting':
+                                resultData = CommonFnUtil.setSecurityPassword( selectedTargetState.selectedTarget.docUID, selectedTargetState.selectedTarget.folder_no,
+                                        0, password.currentPW, password.doubleChkPW);
+                                break;
+                            default:
+                                break;
+                        }
+                        setTimeout(() => {
+                            fnCallback( resultData);
+                        }, (1000));
+                    }
+                    break;
+
                 default:
                     return;
-
-                // case 'MoveDialog':
-                //     resultData = CommonFnUtil.moveDocumentFolder( selectedTargetState.selectedTarget, props);
-                //     break; 
-                // case 'CopyDialog':
-                //     resultData = CommonFnUtil.copyDocument( selectedTargetState.selectedTarget, props);
-                //     break;
             }
 
         } else{
 
+        }
+    };
+
+    const fnCallback = ( resMsg: any) => {
+        if( !resMsg._W){
+            return;
+        }
+        else { 
+            //암호가 일치하지않음 다이얼로그 띄워주고, 포커스 넣기
+            setCenterDialog( '', null);
         }
     };
 
@@ -118,7 +145,7 @@ const CommonHeader = ( props: CommonHeaderInfo) => {
         }
         if( pattern.test( result)) { //특수문자 체크
             Toast.show({
-                type:'success',
+                type:'error',
                 text1: '※ 특수문자는 태그로 등록할 수 없습니다.',
                 visibilityTime: 1000,
                 autoHide: true
@@ -136,7 +163,7 @@ const CommonHeader = ( props: CommonHeaderInfo) => {
             for( let i = 0; i < values.length; i++) {
                 if( values[i].length > 21) {
                     Toast.show({
-                        type:'success',
+                        type:'error',
                         text1: '※ 태그 1개당 20자를 초과할 수 없습니다.',
                         visibilityTime: 1000,
                         autoHide: true
@@ -147,7 +174,7 @@ const CommonHeader = ( props: CommonHeaderInfo) => {
         }
         if ( values && values.length > 10) { //태그 갯수 제한
             Toast.show({
-                type:'success',
+                type:'error',
                 text1: '※ 태그는 10개까지 입력 가능합니다.',
                 visibilityTime: 1000,
                 autoHide: true
@@ -209,7 +236,12 @@ const CommonHeader = ( props: CommonHeaderInfo) => {
                 <View>
                     {
                         headerMenuInfo.rightDialogBtn.map(( btnInfo: any) => {
-                            if(btnInfo.visibility){
+                            if( contextName === 'SecurityDialog' && headerDataInfos.currErrorStatus) {
+                                <View>
+                                    <SvgIcon name = { btnInfo.iconName} width={20} height={20}/>
+                                </View>
+                            }
+                            else if( btnInfo.visibility){
                                 return(
                                     <TouchableOpacity key={ btnInfo.iconName} onPress={ onClickRightBtn.bind( this, 'dialog')}>
                                         <View>

--- a/src/dialog/TagDialog.tsx
+++ b/src/dialog/TagDialog.tsx
@@ -5,7 +5,6 @@ import { dialogStyles} from './style/style';
 import CommonHeader from '../component/header/CommonHeader';
 import { CommonContext } from '../context/CommonContext';
 import CommonFnUtil from '../utils/CommonFnUtil';
-import Toast from 'react-native-toast-message';
 import { CommonDialogToast} from '../component/CommonDialogToast';
 
 const CONTEXT_NAME = 'TagDialog';

--- a/src/ecmadapter/ProtocalList.ts
+++ b/src/ecmadapter/ProtocalList.ts
@@ -117,6 +117,7 @@ export const protocolList = [
     {"protocolId":"P620","protocolNm":"UpdateUserImg","protocolUrl":"https://dev.amaranth10.co.kr/proxymgw/proxymgw30A57"},
     {"protocolId":"P538","protocolNm":"UpdateUserImg","protocolUrl":"https://dev.amaranth10.co.kr/proxymgw/proxymgw30A38"},
     {"protocolId":"P627","protocolNm":"UpdateUserImg","protocolUrl":"https://dev.amaranth10.co.kr/proxymgw/proxymgw30A61"},
+    {"protocolId":"P617","protocolNm":"UpdateUserImg","protocolUrl":"https://dev.amaranth10.co.kr/proxymgw/proxymgw30A54"},
 ];
 
 

--- a/src/utils/CommonFnUtil.tsx
+++ b/src/utils/CommonFnUtil.tsx
@@ -468,7 +468,7 @@ export default class CommonFnUtil{
                 });
             } else {
                 Toast.show({
-                    type: 'success',
+                    type: 'error',
                     text1: '태그등록에 실패했습니다.',
                     visibilityTime: 1000,
                     autoHide: true
@@ -476,7 +476,7 @@ export default class CommonFnUtil{
             }
         }).catch((error) => {
             Toast.show({
-                type: 'success',
+                type: 'error',
                 text1: '실패했습니다.',
                 visibilityTime: 1000,
                 autoHide: true
@@ -500,6 +500,75 @@ export default class CommonFnUtil{
             }
         }).catch(( error) => {
             console.log( error)
+        })
+
+        return result;
+    }
+
+    public static setSecurityPassword = async( strDocSeq: any, strFolderSeq: any, bAct: any, strPassword: any, strNewPassword:any ) => {
+        let result: any = null;
+        const sctyInfo = {"docUID" : strDocSeq, "security_key" : strPassword, "security_new_key" : strNewPassword, "security_type": bAct+""};
+        switch ( bAct) {
+            case 0:		sctyInfo.security_new_key = strNewPassword;		break; //설정
+            case 1:		sctyInfo.security_new_key = strNewPassword;	    break; //변경
+            case 2:		sctyInfo.security_new_key = "";				    break; //해제
+        }
+
+        const data:any = {
+            protocolId : 'P617',
+            data : {"docUID" : sctyInfo.docUID, "security_key" : sctyInfo.security_key, "security_new_key" : sctyInfo.security_new_key,"security_type" : sctyInfo.security_type}
+        };
+
+        await Adapter.fetch.protocol(data).then((res) => {
+            if( res === 0 || res === 1 ) {
+                /**
+                 * History 서버 등록 추후 작업 필요
+                 * 
+                 * oneffice.currFileSecurityStatus = true; 
+                 * 
+                 * let nHistoryCode = '';
+                    if (bAct === 2) { //해제
+                        nHistoryCode = '10';
+                        // oneffice.currFileSecurityStatus = false;
+                    } else if (bAct === 0) { //설정
+                        nHistoryCode = '8';
+                    } else {
+                        nHistoryCode = '9';
+                    }
+                 * 
+                 * onefficeMGW.accessDocumentHistory(responseData, nHistoryCode);
+                 */
+
+                let strMsg = '';
+                
+                switch (bAct) {
+                    case 0:		strMsg = '암호가 설정되었습니다.';		break;	//설정
+                    case 1:		strMsg = '암호가 변경되었습니다.';		break;	//변경
+                    case 2:		strMsg = '암호가 해제되었습니다.';		break;	//해제			
+                }
+
+                Toast.show({
+                    type: 'success',
+                    text1: strMsg,
+                    visibilityTime: 1000,
+                    autoHide: true
+                });
+
+                result = strMsg;
+                
+                return result;
+            }
+        }).catch((error) => {
+            // console.log( error);
+            Toast.show({
+                type: 'error',
+                text1: error.message,
+                visibilityTime: 1000,
+                autoHide: true
+            });
+            result = false;
+
+            return result;
         })
 
         return result;


### PR DESCRIPTION
1.보안설정 기능 구현(80%)
 - 프로토콜 리스트 추가
 - api 호출 함수 개발
 - 비밀번호 설정/변경 동작 구현 완료
    > 헤더쪽에 아래와 같은 정보 props로 넘겨줌
       1) 비밀번호 값
         > 설정의 경우: 암호, 암호 확인
         > 변경의 경우: 현재 암호, 새 암호
       2)  헤더 데이타 인포
         > 비밀번호 에러 유/무
         > 현재 선택된 문서보안설정타입 값(변경/ 해제)

 - 보완 필요한 점 
   1) 설정 비활성화 icon svg  추가 필요 
   2) 비밀번호 해제 동작안함 디버깅 필요